### PR TITLE
Implement `preserve` method and add some docs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManualMemory"
 uuid = "d125e4d3-2237-4719-b19c-fa641b8a4667"
 authors = ["chriselrod <elrodc@gmail.com> and contributors"]
-version = "0.1.1"
+version = "0.1.2"
 
 [compat]
 julia = "1.5"

--- a/src/ManualMemory.jl
+++ b/src/ManualMemory.jl
@@ -44,7 +44,7 @@ struct LazyPreserve{A,P}
 end
 LazyPreserve(arg) = LazyPreserve(arg, nothing)
 (p::LazyPreserve)(x) = p.ptrcall(x, p.arg)
-(p::LazyPreserve{A,Nothing})(x) where {A} = p.ptrcall(x)
+(p::LazyPreserve{A,Nothing})(x) where {A} = pointer(x)
 
 
 """
@@ -223,7 +223,7 @@ function _unwrap_preserve(body::Expr, pres::Expr, argexpr::Expr, argtype::Type)
         bufsym = gensym()
         push!(body.args, Expr(:(=), bufsym, Expr(:call, :preserve_buffer, argexpr)))
         push!(pres.args, bufsym)
-        return :(pointer($bufsym))
+        return :($argexpr($bufsym))
     else
         return argexpr
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using ManualMemory: MemoryBuffer, load, store!
+using ManualMemory: MemoryBuffer, load, store!, LazyPreserve, preserve
 using Test
 
 @testset "ManualMemory.jl" begin
@@ -12,6 +12,10 @@ using Test
     store!(Base.unsafe_convert(Ptr{String}, m), str)
     @test load(Base.unsafe_convert(Ptr{String}, m)) === str
   end
+
+  x = [0 0; 0 0];
+  preserve(store!, LazyPreserve(x), 1)
+  @test x[1] === 1
 end
 
 using ThreadingUtilities


### PR DESCRIPTION
Using the `@gc_preserve` macro found elsewhere as a template I implemented `preserve(op, args...; kwargs...)`. I used a generated function instead of a macro so that `LazyPreserve` could easily indicate which arguments should be unwrapped, preserved, and converted to a pointer. I also copied the docstring for `preserve_buffer` in a small attempt to document the components of `preserve`.