### PR TITLE
PseudoPtr

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManualMemory"
 uuid = "d125e4d3-2237-4719-b19c-fa641b8a4667"
 authors = ["chriselrod <elrodc@gmail.com> and contributors"]
-version = "0.1.3"
+version = "0.1.4"
 
 [compat]
 julia = "1.5"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,9 @@ using Test
   p += 1
   store!(p, 2)
   @test load(p) === 2
+  p = 1 + p
+  store!(p, 3)
+  @test load(p) === 3
 end
 
 using ThreadingUtilities

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using ManualMemory: MemoryBuffer, load, store!, LazyPreserve, preserve
+using ManualMemory: MemoryBuffer, load, store!, LazyPreserve, preserve, PseudoPtr
 using Test
 
 @testset "ManualMemory.jl" begin
@@ -16,6 +16,11 @@ using Test
   x = [0 0; 0 0];
   preserve(store!, LazyPreserve(x), 1)
   @test x[1] === 1
+  p = PseudoPtr(x, 1)
+  @test load(p) === 1
+  p += 1
+  store!(p, 2)
+  @test load(p) === 2
 end
 
 using ThreadingUtilities


### PR DESCRIPTION
The motivation for this was to make code that expects a pointer work generically. For example:
```julia
function copy_each(x, y, inds)
    if x isa Array
        p = pointer(x)
    else
        p = PseudoPtr(x)
    end
    @inbounds for i in inds
        store!(p, y[i])
        p += 1
    end
    return x
end
```
The non MWE version that I'm really aiming for here generates that inner loop independent of whether `x` and `y` can form a pointer.