### PR TITLE
Add `buffer` method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,11 @@
 name = "ManualMemory"
 uuid = "d125e4d3-2237-4719-b19c-fa641b8a4667"
 authors = ["chriselrod <elrodc@gmail.com> and contributors"]
-version = "0.1.6"
+version = "0.1.7"
+
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 julia = "1.5"

--- a/src/ManualMemory.jl
+++ b/src/ManualMemory.jl
@@ -147,9 +147,11 @@ BenchmarkTools.Trial:
 ```
 """
 @inline preserve_buffer(x::LazyPreserve) = preserve_buffer(x.arg)
-@inline preserve_buffer(x) = _preserve_buffer(x, buffer(x))
-@inline _preserve_buffer(a::A, p::P) where {A,P} = _preserve_buffer(p, buffer(p))
-@inline _preserve_buffer(a::A, p::A) where {A} = a
+@inline preserve_buffer(x) = x
+@inline preserve_buffer(A::AbstractArray) = _preserve_buffer(A, parent(A))
+@inline _preserve_buffer(a::A, p::P) where {A,P<:AbstractArray} = _preserve_buffer(p, parent(p))
+@inline _preserve_buffer(a::A, p::A) where {A<:AbstractArray} = a
+@inline _preserve_buffer(a::A, p::P) where {A,P} = p
 
 function load_aggregate(::Type{T}, offset::Int) where {T}
   numfields = fieldcount(T)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,7 +1,10 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 ThreadingUtilities = "8290d209-cae3-49c0-8002-c8c24d57dab5"
 VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,13 @@
+using ManualMemory
 using ManualMemory: MemoryBuffer, load, store!, LazyPreserve, preserve, PseudoPtr, Reference
+using SparseArrays
+using LinearAlgebra
 using Test
 
 @testset "ManualMemory.jl" begin
+  @test ManualMemory.buffer(sparse([1; 2; 3], [1; 2; 3], [1; 2; 3])) ==
+    ManualMemory.buffer(sparsevec([1, 2, 0, 0, 3, 0])) ==
+    ManualMemory.buffer(Diagonal([1,2,3]))
 
   @test_throws AssertionError MemoryBuffer{4,String}(undef)
   m = MemoryBuffer{4,Float64}(undef);


### PR DESCRIPTION
* Added `buffer`: The difference between this and `preserve_buffer` is that it only goes one layer deep. The primary motivation for this is when we want to basically perform `parent` but there is no formal parent array and we don't care if we get an array type out of it (sparse arrays are a good example of this).
* Added dependencies: `SparseArrays` and `LinearAlgebra`. Figured this was fine since they were standard libraries.
* Use `buffer` internally for `preserve_buffer`: No changes to tests for this to pass, but I wanted to make you aware since last time I did something like this it caused a bunch of upstream errors from ArrayInterface.jl.