### PR TITLE
Fix `docs/make.jl` for document deployment

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,11 +6,11 @@ DocMeta.setdocmeta!(ManualMemory, :DocTestSetup, :(using ManualMemory); recursiv
 makedocs(;
     modules=[ManualMemory],
     authors="chriselrod <elrodc@gmail.com> and contributors",
-    repo="https://github.com/chriselrod/ManualMemory.jl/blob/{commit}{path}#{line}",
+    repo="https://github.com/JuliaSIMD/ManualMemory.jl/blob/{commit}{path}#{line}",
     sitename="ManualMemory.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://chriselrod.github.io/ManualMemory.jl",
+        canonical="https://JuliaSIMD.github.io/ManualMemory.jl",
         assets=String[],
     ),
     pages=[
@@ -19,5 +19,6 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/chriselrod/ManualMemory.jl",
+    repo="github.com/JuliaSIMD/ManualMemory.jl",
+    devbranch="main",
 )


### PR DESCRIPTION
The document page (https://juliasimd.github.io/ManualMemory.jl/dev) returns 404 because some settings in `docs/make.jl` is not correct.

![image](https://github.com/JuliaSIMD/ManualMemory.jl/assets/7488140/5eb13423-5835-4920-89ff-c8f8ef22994c)

https://github.com/JuliaSIMD/ManualMemory.jl/actions/runs/4406218531/jobs/7718150211

This PR fixes this problem.